### PR TITLE
feature/AMLG-6294-update-whisper-deployment-memory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 .git
 .venv
 venv
+docker-compose.yml
+docker-compose.gpu.yml

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -35,6 +35,6 @@ COPY --from=swagger-ui /usr/share/nginx/html/swagger-ui.css swagger-ui-assets/sw
 COPY --from=swagger-ui /usr/share/nginx/html/swagger-ui-bundle.js swagger-ui-assets/swagger-ui-bundle.js
 
 RUN poetry install
-RUN $POETRY_VENV/bin/pip install torch==1.13.0+cu117 -f https://download.pytorch.org/whl/torch
+RUN $POETRY_VENV/bin/pip install torch==1.13.1+cu117 -f https://download.pytorch.org/whl/torch
 
 CMD gunicorn --bind 0.0.0.0:9000 --workers 1 --timeout 0 app.webservice:app -k uvicorn.workers.UvicornWorker

--- a/app/faster_whisper/utils.py
+++ b/app/faster_whisper/utils.py
@@ -133,9 +133,9 @@ def format_json(json_file):
         'compression_ratio': segment[8],
         'no_speech_prob': segment[9],
         'words': [{
-            'word': word[0],
-            'start': word[1],
-            'end': word[2],
+            'word': word[2],
+            'start': word[0],
+            'end': word[1],
             'probability': word[3]
         } for word in segment[10]]
     } for segment in json_file['segments']]

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -11,9 +11,10 @@ services:
           devices:
             - driver: nvidia
               count: 1
-              capabilities: [gpu]
+              capabilities: [ gpu ]
     environment:
-      - ASR_MODEL=base
+      - ASR_ENGINE=faster_whisper
+      - ASR_MODEL=medium.en
     ports:
       - 9000:9000
     volumes:

--- a/infrastructure/whisper/templates/whisper-deployment.yaml
+++ b/infrastructure/whisper/templates/whisper-deployment.yaml
@@ -40,6 +40,6 @@ spec:
             - name: ASR_ENGINE
               value: faster_whisper
             - name: ASR_MODEL
-              value: base
+              value: medium.en
       nodeSelector:
         cloud.google.com/gke-nodepool: "splice-xcd-gpu-t4"

--- a/infrastructure/whisper/values.prod.yaml
+++ b/infrastructure/whisper/values.prod.yaml
@@ -8,11 +8,11 @@ whisperDeployment:
   resources:
     limits:
       cpu: "2000m"
-      memory: "2Gi"
+      memory: "8Gi"
       gpu: "1"
     request:
       cpu: "1000m"
-      memory: "1Gi"
+      memory: "6Gi"
       gpu: "1"
 
 whisperService:

--- a/infrastructure/whisper/values.yaml
+++ b/infrastructure/whisper/values.yaml
@@ -8,11 +8,11 @@ whisperDeployment:
   resources:
     limits:
       cpu: "2000m"
-      memory: "10Gi"
+      memory: "8Gi"
       gpu: "1"
     request:
       cpu: "1000m"
-      memory: "8Gi"
+      memory: "6Gi"
       gpu: "1"
 
 whisperService:

--- a/infrastructure/whisper/values.yaml
+++ b/infrastructure/whisper/values.yaml
@@ -8,11 +8,11 @@ whisperDeployment:
   resources:
     limits:
       cpu: "2000m"
-      memory: "2Gi"
+      memory: "10Gi"
       gpu: "1"
     request:
       cpu: "1000m"
-      memory: "1Gi"
+      memory: "8Gi"
       gpu: "1"
 
 whisperService:


### PR DESCRIPTION
Updated the values for memory as `medium.en` requires 3GB hence it was not able to stand up in the pods. Dev was manually patched to test and it works. This just aligns the code and we've moved `docker-compose` to `.dockerignore`