### PR TITLE
Update max size

### DIFF
--- a/infrastructure/whisper/templates/whisper-ingress.yaml
+++ b/infrastructure/whisper/templates/whisper-ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: video-services
   annotations:
     nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
 {{- include "whisper-api.labels" . | nindent 2}}
 spec:
   rules:


### PR DESCRIPTION
We're getting 413 errors from the service for requests being too large, updated max size to 100m 